### PR TITLE
fix: clean up resize observer

### DIFF
--- a/src/hooks/useOverflowingHorizontalListItems/useOverflowingHorizontalListItems.ts
+++ b/src/hooks/useOverflowingHorizontalListItems/useOverflowingHorizontalListItems.ts
@@ -36,9 +36,6 @@ export function useOverflowingHorizontalListItems<ItemType>({
 
     useLayoutEffect(() => {
         const footerMenu = containerRef.current;
-        if (!footerMenu) {
-            return;
-        }
 
         const updateContainerSize = (entries: ResizeObserverEntry[]) => {
             if (entries.length > 0 && footerMenu) {
@@ -49,7 +46,14 @@ export function useOverflowingHorizontalListItems<ItemType>({
         const updateContainerSizeDebounced = debounceFn(updateContainerSize, 100);
         const footerMenuResizeObserver = new ResizeObserver(updateContainerSizeDebounced);
 
-        footerMenuResizeObserver.observe(footerMenu);
+        if (footerMenu) {
+            footerMenuResizeObserver.observe(footerMenu);
+        }
+
+        return () => {
+            updateContainerSizeDebounced.cancel();
+            footerMenuResizeObserver.disconnect();
+        };
     }, [containerRef]);
 
     const isMeasured = containerWidth > 0;


### PR DESCRIPTION
## Summary
- ensure ResizeObserver is disconnected and debounced callback cancelled in `useOverflowingHorizontalListItems`

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68ab395e34748332925ea18992d38743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added.
- Bug Fixes
  - Prevented rare initialization errors when the footer menu isn’t present.
  - Ensured width updates only occur when the element exists, avoiding null access.
- Refactor
  - Improved cleanup of observers and debounced handlers to reduce potential leaks and stabilize behavior.
- Tests
  - No changes.
- Documentation
  - No changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->